### PR TITLE
Adds option for custom local tags. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ By default, exception messages are prefixed with `[safely]`. This makes it easie
 Safely.tag = false
 ```
 
+You can also add custom tags to a safely block:
+
+```ruby
+safely(tag: "Issue123"){ code } #=> "[Issue123] Some Exception Message"
+```
+
 ## Installation
 
 Add this line to your application’s Gemfile:

--- a/test/safely_test.rb
+++ b/test/safely_test.rb
@@ -75,6 +75,26 @@ class TestSafely < Minitest::Test
     assert true
   end
 
+  def test_default_tag
+    exception = Safely::TestError.new("Boom")
+    safely {raise exception}
+    assert_equal "[safely] Boom", exception.message
+  end
+
+  def test_no_tag
+    Safely.tag = false
+    exception = Safely::TestError.new("Boom")
+    safely {raise exception}
+    assert_equal "Boom", exception.message
+    Safely.tag = "safely"
+  end
+
+  def test_local_tag
+    exception = Safely::TestError.new("Boom")
+    safely(tag: "Issue 123"){raise exception}
+    assert_equal "[Issue 123] Boom", exception.message
+  end
+
   def test_failsafe
     Safely.report_exception_method = proc { raise "oops" }
     out, err = capture_io do


### PR DESCRIPTION
 Useful when a bug has an associated ticket already so you can tag it appropriately.  Thoughts?

Used like this:

```
safely(tag: "Issue1"){} #=> "[issue1] exception text"
```

The only issue I can think of is the behavior when Safely.tag = false, should local tags still be honored? 
