### PR TITLE
Fix broken gemspec

### DIFF
--- a/lib/safely_block.rb
+++ b/lib/safely_block.rb
@@ -1,8 +1,6 @@
 require "errbase"
 
 module Safely
-  VERSION = "0.1.0"
-
   class << self
     attr_accessor :env, :raise_envs, :tag, :report_exception_method
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,0 +1,3 @@
+module Safely
+  VERSION = "0.1.0"
+end

--- a/safely_block.gemspec
+++ b/safely_block.gemspec
@@ -1,7 +1,4 @@
-# coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "safely_block"
+require File.expand_path("../lib/version.rb", __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name          = "safely_block"
@@ -10,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["andrew@chartkick.com"]
   spec.summary       = "Awesome exception handling"
   spec.description   = "Awesome exception handling"
-  spec.homepage      = "https://github.com/ankane/safely_block"
+  spec.homepage      = "https://github.com/ankane/safely"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
I just cloned your repository and couldn't `bundle install` because your `.gemspec` file was broken. Here is why:
You were requiring `safely_block.rb` in order to load your gem `VERSION` constant, but in that same file you had a `require "errbase"`, which would not be available in the first place.
Also, putting you gem version in a separate file is always desirable because it provides a better isolation in bump commits among other advantages.