### PR TITLE
Add safely_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,26 @@ end
 
 **Note:** The throttle limit is approximate and per process.
 
+Wrap a method
+
+```ruby
+def foo
+  # your code
+end
+safely_method :foo
+```
+
+will wrap the `foo` method content inside a `safely` block.
+
+Also, you can pass any options to the `safely` method like this:
+
+```ruby
+def foo
+  # your code
+end
+safely_method :foo, default: "bar"
+```
+
 ## Reporting
 
 Reports exceptions to a variety of services out of the box thanks to [Errbase](https://github.com/ankane/errbase).

--- a/lib/safely/core.rb
+++ b/lib/safely/core.rb
@@ -54,4 +54,23 @@ module Safely
     alias_method :yolo, :safely
   end
   extend Methods
+
+  module ClassMethods
+    def safely_method(method_id, options = {})
+      original_method_id = :"_safely_method_#{method_id}"
+      alias_method original_method_id, method_id
+
+      define_method method_id do |*args, &blk|
+        safely(options) do
+          send(original_method_id, *args, &blk)
+        end
+      end
+
+      if private_instance_methods.include?(original_method_id)
+        private method_id
+      elsif protected_instance_methods.include?(original_method_id)
+        protected method_id
+      end
+    end
+  end
 end

--- a/lib/safely_block.rb
+++ b/lib/safely_block.rb
@@ -1,3 +1,5 @@
 require "safely/core"
 
 Object.send :include, Safely::Methods
+Class.send :include, Safely::ClassMethods
+Module.send :include, Safely::ClassMethods


### PR DESCRIPTION
Adds a syntax sugar for cases when entire method's content will be wrapped inside a `safely` block. So instead of:

``` ruby
def foo
  safely do
    # your code
  end
end
```

you can use this syntax:

``` ruby
def foo
  # your code
end
safely_method :foo
```
